### PR TITLE
features/answer attachments

### DIFF
--- a/src/domain/forum/application/repositories/answer-attachments-repository.ts
+++ b/src/domain/forum/application/repositories/answer-attachments-repository.ts
@@ -1,6 +1,8 @@
 import { AnswerAttachment } from '../../enterprise/entities/answer-attachment'
 
 export abstract class AnswerAttachmentsRepository {
+  abstract createMany(attachments: AnswerAttachment[]): Promise<void>
+  abstract deleteMany(attachments: AnswerAttachment[]): Promise<void>
   abstract findManyByAnswerId(answerId: string): Promise<AnswerAttachment[]>
   abstract deleteManyByAnswerId(answerId: string): Promise<void>
 }

--- a/src/domain/forum/application/use-cases/answer-question.spec.ts
+++ b/src/domain/forum/application/use-cases/answer-question.spec.ts
@@ -45,4 +45,26 @@ describe('Create Answer Use Case', () => {
       ],
     )
   })
+
+  it('should persist attachments when creating a new answer', async () => {
+    const result = await sut.execute({
+      authorId: '1',
+      questionId: '1',
+      content: 'New content',
+      attachmentsIds: ['1', '2'],
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(inMemoryAnswerAttachmentsRepository.items).toHaveLength(2)
+    expect(inMemoryAnswerAttachmentsRepository.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          attachmentId: new UniqueEntityID('1'),
+        }),
+        expect.objectContaining({
+          attachmentId: new UniqueEntityID('2'),
+        }),
+      ]),
+    )
+  })
 })

--- a/src/domain/forum/application/use-cases/create-question.spec.ts
+++ b/src/domain/forum/application/use-cases/create-question.spec.ts
@@ -46,7 +46,7 @@ describe('Create Question Use Case', () => {
     ])
   })
 
-  it('should be persist attachments when creating a new question', async () => {
+  it('should persist attachments when creating a new question', async () => {
     const result = await sut.execute({
       authorId: '1',
       title: 'New title',

--- a/src/domain/forum/application/use-cases/edit-answer.spec.ts
+++ b/src/domain/forum/application/use-cases/edit-answer.spec.ts
@@ -106,4 +106,45 @@ describe('Edit Answer Use Case', () => {
     expect(result.isLeft()).toBe(true)
     expect(result.value).toBeInstanceOf(ResourceNotFoundError)
   })
+
+  it('should be able to sync new and removed attachments when editing a answer', async () => {
+    const newAnswer = makeAnswer(
+      { authorId: new UniqueEntityID('author-1') },
+      new UniqueEntityID('answer-1'),
+    )
+
+    await inMemoryAnswersRepository.create(newAnswer)
+
+    inMemoryAnswerAttachmentsRepository.items.push(
+      makeAnswerAttachment({
+        answerId: newAnswer.id,
+        attachmentId: new UniqueEntityID('1'),
+      }),
+
+      makeAnswerAttachment({
+        answerId: newAnswer.id,
+        attachmentId: new UniqueEntityID('2'),
+      }),
+    )
+
+    const result = await sut.execute({
+      authorId: 'author-1',
+      answerId: 'answer-1',
+      content: 'Updated content',
+      attachmentsIds: ['1', '3'],
+    })
+
+    expect(result.isRight()).toBe(true)
+    expect(inMemoryAnswerAttachmentsRepository.items).toHaveLength(2)
+    expect(inMemoryAnswerAttachmentsRepository.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          attachmentId: new UniqueEntityID('1'),
+        }),
+        expect.objectContaining({
+          attachmentId: new UniqueEntityID('3'),
+        }),
+      ]),
+    )
+  })
 })

--- a/src/infra/database/prisma/mappers/prisma-answer-attachment-mapper.ts
+++ b/src/infra/database/prisma/mappers/prisma-answer-attachment-mapper.ts
@@ -1,4 +1,4 @@
-import { Attachment as PrismaAttachment } from '@prisma/client'
+import { Prisma, Attachment as PrismaAttachment } from '@prisma/client'
 import { UniqueEntityID } from '@/core/entities/unique-entity-id'
 import { AnswerAttachment } from '@/domain/forum/enterprise/entities/answer-attachment'
 
@@ -15,5 +15,24 @@ export class PrismaAnswerAttachmentMapper {
       },
       new UniqueEntityID(raw.id),
     )
+  }
+
+  static toPrismaUpdateMany(
+    attachments: AnswerAttachment[],
+  ): Prisma.AttachmentUpdateManyArgs {
+    const attachmentIds = attachments.map((attachment) => {
+      return attachment.attachmentId.toString()
+    })
+
+    return {
+      where: {
+        id: {
+          in: attachmentIds,
+        },
+      },
+      data: {
+        answerId: attachments[0].answerId.toString(),
+      },
+    }
   }
 }

--- a/src/infra/database/prisma/repositories/prisma-answer-attachments-repository.ts
+++ b/src/infra/database/prisma/repositories/prisma-answer-attachments-repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common'
 import { AnswerAttachmentsRepository } from '@/domain/forum/application/repositories/answer-attachments-repository'
 import { PrismaService } from '../prisma.service'
 import { PrismaAnswerAttachmentMapper } from '../mappers/prisma-answer-attachment-mapper'
+import { AnswerAttachment } from '@/domain/forum/enterprise/entities/answer-attachment'
 
 @Injectable()
 export class PrismaAnswerAttachmentsRepository
@@ -17,6 +18,34 @@ export class PrismaAnswerAttachmentsRepository
     })
 
     return answerAttachments.map(PrismaAnswerAttachmentMapper.toDomain)
+  }
+
+  async createMany(attachments: AnswerAttachment[]) {
+    if (attachments.length === 0) {
+      return
+    }
+
+    const data = PrismaAnswerAttachmentMapper.toPrismaUpdateMany(attachments)
+
+    await this.prisma.attachment.updateMany(data)
+  }
+
+  async deleteMany(attachments: AnswerAttachment[]) {
+    if (attachments.length === 0) {
+      return
+    }
+
+    const attachmentIds = attachments.map((attachment) => {
+      return attachment.id.toString()
+    })
+
+    await this.prisma.attachment.deleteMany({
+      where: {
+        id: {
+          in: attachmentIds,
+        },
+      },
+    })
   }
 
   async deleteManyByAnswerId(answerId: string) {

--- a/src/infra/database/prisma/repositories/prisma-answers-repository.ts
+++ b/src/infra/database/prisma/repositories/prisma-answers-repository.ts
@@ -4,10 +4,14 @@ import { Answer } from '@/domain/forum/enterprise/entities/answer'
 import { Injectable } from '@nestjs/common'
 import { PrismaService } from '../prisma.service'
 import { PrismaAnswerMapper } from '../mappers/prisma-answer-mapper'
+import { AnswerAttachmentsRepository } from '@/domain/forum/application/repositories/answer-attachments-repository'
 
 @Injectable()
 export class PrismaAnswersRepository implements AnswersRepository {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly answerAttachmentsRepository: AnswerAttachmentsRepository,
+  ) {}
 
   async findById(id: string) {
     const answer = await this.prisma.answer.findUnique({
@@ -38,21 +42,35 @@ export class PrismaAnswersRepository implements AnswersRepository {
     return answers.map(PrismaAnswerMapper.toDomain)
   }
 
+  async save(answer: Answer) {
+    const data = PrismaAnswerMapper.toPrisma(answer)
+
+    await Promise.all([
+      this.prisma.answer.update({
+        where: {
+          id: data.id,
+        },
+        data,
+      }),
+
+      this.answerAttachmentsRepository.createMany(
+        answer.attachments.getNewItems(),
+      ),
+
+      this.answerAttachmentsRepository.deleteMany(
+        answer.attachments.getRemovedItems(),
+      ),
+    ])
+  }
+
   async create(answer: Answer) {
     const data = PrismaAnswerMapper.toPrisma(answer)
 
     await this.prisma.answer.create({ data })
-  }
 
-  async save(answer: Answer) {
-    const data = PrismaAnswerMapper.toPrisma(answer)
-
-    await this.prisma.answer.update({
-      where: {
-        id: data.id,
-      },
-      data,
-    })
+    await this.answerAttachmentsRepository.createMany(
+      answer.attachments.getItems(),
+    )
   }
 
   async delete(answer: Answer) {

--- a/src/infra/database/prisma/repositories/prisma-questions-repository.ts
+++ b/src/infra/database/prisma/repositories/prisma-questions-repository.ts
@@ -85,11 +85,9 @@ export class PrismaQuestionsRepository implements QuestionsRepository {
   }
 
   async delete(question: Question) {
-    const data = PrismaQuestionMapper.toPrisma(question)
-
     await this.prisma.question.delete({
       where: {
-        id: data.id,
+        id: question.id.toString(),
       },
     })
   }

--- a/src/infra/http/controllers/answer-question.controller.e2e-spec.ts
+++ b/src/infra/http/controllers/answer-question.controller.e2e-spec.ts
@@ -10,23 +10,26 @@ import { PrismaService } from '@/infra/database/prisma/prisma.service'
 
 import { StudentFactory } from 'test/factories/make-student'
 import { QuestionFactory } from 'test/factories/make-question'
+import { AttachmentFactory } from 'test/factories/make-attachment'
 
 describe('Answer question (E2E)', () => {
   let app: INestApplication
   let studentFactory: StudentFactory
   let questionFactory: QuestionFactory
+  let attachmentFactory: AttachmentFactory
   let prisma: PrismaService
   let jwt: JwtService
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule, DatabaseModule],
-      providers: [StudentFactory, QuestionFactory],
+      providers: [StudentFactory, QuestionFactory, AttachmentFactory],
     }).compile()
 
     app = moduleRef.createNestApplication()
     studentFactory = moduleRef.get(StudentFactory)
     questionFactory = moduleRef.get(QuestionFactory)
+    attachmentFactory = moduleRef.get(AttachmentFactory)
     prisma = moduleRef.get(PrismaService)
     jwt = moduleRef.get(JwtService)
 
@@ -42,6 +45,9 @@ describe('Answer question (E2E)', () => {
       authorId: user.id,
     })
 
+    const attachment1 = await attachmentFactory.makePrismaAttachment()
+    const attachment2 = await attachmentFactory.makePrismaAttachment()
+
     const questionId = question.id.toString()
 
     const content = 'New Answer'
@@ -49,7 +55,10 @@ describe('Answer question (E2E)', () => {
     const response = await request(app.getHttpServer())
       .post(`/questions/${questionId}/answers`)
       .set('Authorization', `Bearer ${accessToken}`)
-      .send({ content })
+      .send({
+        content,
+        attachments: [attachment1.id.toString(), attachment2.id.toString()],
+      })
 
     expect(response.statusCode).toBe(201)
 
@@ -60,5 +69,13 @@ describe('Answer question (E2E)', () => {
     })
 
     expect(answerOnDatabase).toBeTruthy()
+
+    const attachmentsOnDatabase = await prisma.attachment.findMany({
+      where: {
+        answerId: answerOnDatabase?.id,
+      },
+    })
+
+    expect(attachmentsOnDatabase).toHaveLength(2)
   })
 })

--- a/src/infra/http/controllers/answer-question.controller.ts
+++ b/src/infra/http/controllers/answer-question.controller.ts
@@ -14,6 +14,7 @@ import { AnswerQuestionUseCase } from '@/domain/forum/application/use-cases/answ
 
 const answerQuestionBodySchema = z.object({
   content: z.string(),
+  attachments: z.array(z.string().uuid()),
 })
 
 type AnswerQuestionBodySchema = z.infer<typeof answerQuestionBodySchema>
@@ -31,13 +32,13 @@ export class AnswerQuestionController {
     @Param('questionId') questionId: string,
   ) {
     const userId = user.sub
-    const { content } = body
+    const { content, attachments } = body
 
     const result = await this.answerQuestion.execute({
       content,
       questionId,
       authorId: userId,
-      attachmentsIds: [],
+      attachmentsIds: attachments,
     })
 
     if (result.isLeft()) {

--- a/src/infra/http/controllers/edit-answer.controller.e2e-spec.ts
+++ b/src/infra/http/controllers/edit-answer.controller.e2e-spec.ts
@@ -11,25 +11,37 @@ import { PrismaService } from '@/infra/database/prisma/prisma.service'
 import { StudentFactory } from 'test/factories/make-student'
 import { QuestionFactory } from 'test/factories/make-question'
 import { AnswerFactory } from 'test/factories/make-answer'
+import { AttachmentFactory } from 'test/factories/make-attachment'
+import { AnswerAttachmentFactory } from 'test/factories/make-answer-attachment'
 
 describe('Edit answer (E2E)', () => {
   let app: INestApplication
   let studentFactory: StudentFactory
   let questionFactory: QuestionFactory
   let answerFactory: AnswerFactory
+  let attachmentFactory: AttachmentFactory
+  let answerAttachmentFactory: AnswerAttachmentFactory
   let prisma: PrismaService
   let jwt: JwtService
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule, DatabaseModule],
-      providers: [StudentFactory, QuestionFactory, AnswerFactory],
+      providers: [
+        StudentFactory,
+        QuestionFactory,
+        AnswerFactory,
+        AttachmentFactory,
+        AnswerAttachmentFactory,
+      ],
     }).compile()
 
     app = moduleRef.createNestApplication()
     studentFactory = moduleRef.get(StudentFactory)
     questionFactory = moduleRef.get(QuestionFactory)
     answerFactory = moduleRef.get(AnswerFactory)
+    attachmentFactory = moduleRef.get(AttachmentFactory)
+    answerAttachmentFactory = moduleRef.get(AnswerAttachmentFactory)
     prisma = moduleRef.get(PrismaService)
     jwt = moduleRef.get(JwtService)
 
@@ -50,6 +62,21 @@ describe('Edit answer (E2E)', () => {
       authorId: user.id,
     })
 
+    const attachment1 = await attachmentFactory.makePrismaAttachment()
+    const attachment2 = await attachmentFactory.makePrismaAttachment()
+
+    await answerAttachmentFactory.makePrismaAnswerAttachment({
+      attachmentId: attachment1.id,
+      answerId: answer.id,
+    })
+
+    await answerAttachmentFactory.makePrismaAnswerAttachment({
+      attachmentId: attachment2.id,
+      answerId: answer.id,
+    })
+
+    const attachment3 = await attachmentFactory.makePrismaAttachment()
+
     const answerId = answer.id.toString()
 
     const content = 'New answer content'
@@ -57,7 +84,10 @@ describe('Edit answer (E2E)', () => {
     const response = await request(app.getHttpServer())
       .put(`/answers/${answerId}`)
       .set('Authorization', `Bearer ${accessToken}`)
-      .send({ content })
+      .send({
+        content,
+        attachments: [attachment1.id.toString(), attachment3.id.toString()],
+      })
 
     expect(response.statusCode).toBe(204)
 
@@ -68,5 +98,23 @@ describe('Edit answer (E2E)', () => {
     })
 
     expect(answerOnDatabase).toBeTruthy()
+
+    const attachmentsOnDatabase = await prisma.attachment.findMany({
+      where: {
+        answerId: answerOnDatabase?.id,
+      },
+    })
+
+    expect(attachmentsOnDatabase).toHaveLength(2)
+    expect(attachmentsOnDatabase).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: attachment1.id.toString(),
+        }),
+        expect.objectContaining({
+          id: attachment3.id.toString(),
+        }),
+      ]),
+    )
   })
 })

--- a/src/infra/http/controllers/edit-answer.controller.ts
+++ b/src/infra/http/controllers/edit-answer.controller.ts
@@ -14,7 +14,7 @@ import { EditAnswerUseCase } from '@/domain/forum/application/use-cases/edit-ans
 
 const editAnswerBodySchema = z.object({
   content: z.string(),
-  attachments: z.array(z.string().uuid()),
+  attachments: z.array(z.string().uuid()).default([]),
 })
 
 type EditAnswerBodySchema = z.infer<typeof editAnswerBodySchema>

--- a/src/infra/http/controllers/edit-answer.controller.ts
+++ b/src/infra/http/controllers/edit-answer.controller.ts
@@ -14,6 +14,7 @@ import { EditAnswerUseCase } from '@/domain/forum/application/use-cases/edit-ans
 
 const editAnswerBodySchema = z.object({
   content: z.string(),
+  attachments: z.array(z.string().uuid()),
 })
 
 type EditAnswerBodySchema = z.infer<typeof editAnswerBodySchema>
@@ -31,12 +32,12 @@ export class EditAnswerController {
     @Param('id') answerId: string,
   ) {
     const userId = user.sub
-    const { content } = body
+    const { content, attachments } = body
 
     const result = await this.editAnswer.execute({
       content,
       authorId: userId,
-      attachmentsIds: [],
+      attachmentsIds: attachments,
       answerId,
     })
 

--- a/src/infra/http/controllers/edit-question.controller.e2e-spec.ts
+++ b/src/infra/http/controllers/edit-question.controller.e2e-spec.ts
@@ -10,23 +10,34 @@ import { PrismaService } from '@/infra/database/prisma/prisma.service'
 
 import { StudentFactory } from 'test/factories/make-student'
 import { QuestionFactory } from 'test/factories/make-question'
+import { AttachmentFactory } from 'test/factories/make-attachment'
+import { QuestionAttachmentFactory } from 'test/factories/make-question-attachment'
 
 describe('Edit question (E2E)', () => {
   let app: INestApplication
   let studentFactory: StudentFactory
   let questionFactory: QuestionFactory
+  let attachmentFactory: AttachmentFactory
+  let questionAttachmentFactory: QuestionAttachmentFactory
   let prisma: PrismaService
   let jwt: JwtService
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule, DatabaseModule],
-      providers: [StudentFactory, QuestionFactory],
+      providers: [
+        StudentFactory,
+        QuestionFactory,
+        AttachmentFactory,
+        QuestionAttachmentFactory,
+      ],
     }).compile()
 
     app = moduleRef.createNestApplication()
     studentFactory = moduleRef.get(StudentFactory)
     questionFactory = moduleRef.get(QuestionFactory)
+    attachmentFactory = moduleRef.get(AttachmentFactory)
+    questionAttachmentFactory = moduleRef.get(QuestionAttachmentFactory)
     prisma = moduleRef.get(PrismaService)
     jwt = moduleRef.get(JwtService)
 
@@ -42,6 +53,21 @@ describe('Edit question (E2E)', () => {
       authorId: user.id,
     })
 
+    const attachment1 = await attachmentFactory.makePrismaAttachment()
+    const attachment2 = await attachmentFactory.makePrismaAttachment()
+
+    await questionAttachmentFactory.makePrismaQuestionAttachment({
+      attachmentId: attachment1.id,
+      questionId: question.id,
+    })
+
+    await questionAttachmentFactory.makePrismaQuestionAttachment({
+      attachmentId: attachment2.id,
+      questionId: question.id,
+    })
+
+    const attachment3 = await attachmentFactory.makePrismaAttachment()
+
     const questionId = question.id.toString()
 
     const title = 'New Title'
@@ -50,7 +76,11 @@ describe('Edit question (E2E)', () => {
     const response = await request(app.getHttpServer())
       .put(`/questions/${questionId}`)
       .set('Authorization', `Bearer ${accessToken}`)
-      .send({ title, content })
+      .send({
+        title,
+        content,
+        attachments: [attachment1.id.toString(), attachment3.id.toString()],
+      })
 
     expect(response.statusCode).toBe(204)
 
@@ -62,5 +92,22 @@ describe('Edit question (E2E)', () => {
     })
 
     expect(questionOnDatabase).toBeTruthy()
+
+    const attachmentsOnDatabase = await prisma.attachment.findMany({
+      where: {
+        questionId: questionOnDatabase?.id,
+      },
+    })
+
+    expect(attachmentsOnDatabase).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: attachment1.id.toString(),
+        }),
+        expect.objectContaining({
+          id: attachment3.id.toString(),
+        }),
+      ]),
+    )
   })
 })

--- a/src/infra/http/controllers/edit-question.controller.ts
+++ b/src/infra/http/controllers/edit-question.controller.ts
@@ -15,6 +15,7 @@ import { EditQuestionUseCase } from '@/domain/forum/application/use-cases/edit-q
 const editQuestionBodySchema = z.object({
   title: z.string(),
   content: z.string(),
+  attachments: z.array(z.string().uuid()).default([]),
 })
 
 type EditQuestionBodySchema = z.infer<typeof editQuestionBodySchema>
@@ -32,13 +33,13 @@ export class EditQuestionController {
     @Param('id') questionId: string,
   ) {
     const userId = user.sub
-    const { title, content } = body
+    const { title, content, attachments } = body
 
     const result = await this.editQuestion.execute({
       title,
       content,
       authorId: userId,
-      attachmentsIds: [],
+      attachmentsIds: attachments,
       questionId,
     })
 

--- a/test/factories/make-answer-attachment.ts
+++ b/test/factories/make-answer-attachment.ts
@@ -3,6 +3,8 @@ import {
   AnswerAttachment,
   AnswerAttachmentProps,
 } from '@/domain/forum/enterprise/entities/answer-attachment'
+import { PrismaService } from '@/infra/database/prisma/prisma.service'
+import { Injectable } from '@nestjs/common'
 
 export function makeAnswerAttachment(
   override: Partial<AnswerAttachmentProps> = {},
@@ -18,4 +20,26 @@ export function makeAnswerAttachment(
   )
 
   return answerAttachment
+}
+
+@Injectable()
+export class AnswerAttachmentFactory {
+  constructor(private prisma: PrismaService) {}
+
+  async makePrismaAnswerAttachment(
+    data: Partial<AnswerAttachmentProps> = {},
+  ): Promise<AnswerAttachment> {
+    const answerAttachment = makeAnswerAttachment(data)
+
+    await this.prisma.attachment.update({
+      where: {
+        id: answerAttachment.attachmentId.toString(),
+      },
+      data: {
+        answerId: answerAttachment.answerId.toString(),
+      },
+    })
+
+    return answerAttachment
+  }
 }

--- a/test/factories/make-question-attachment.ts
+++ b/test/factories/make-question-attachment.ts
@@ -3,6 +3,8 @@ import {
   QuestionAttachment,
   QuestionAttachmentProps,
 } from '@/domain/forum/enterprise/entities/question-attachment'
+import { PrismaService } from '@/infra/database/prisma/prisma.service'
+import { Injectable } from '@nestjs/common'
 
 export function makeQuestionAttachment(
   override: Partial<QuestionAttachmentProps> = {},
@@ -18,4 +20,26 @@ export function makeQuestionAttachment(
   )
 
   return questionAttachment
+}
+
+@Injectable()
+export class QuestionAttachmentFactory {
+  constructor(private prisma: PrismaService) {}
+
+  async makePrismaQuestionAttachment(
+    data: Partial<QuestionAttachmentProps> = {},
+  ): Promise<QuestionAttachment> {
+    const questionAttachment = makeQuestionAttachment(data)
+
+    await this.prisma.attachment.update({
+      where: {
+        id: questionAttachment.attachmentId.toString(),
+      },
+      data: {
+        questionId: questionAttachment.questionId.toString(),
+      },
+    })
+
+    return questionAttachment
+  }
 }

--- a/test/repositories/in-memory-answer-attachments-repository.ts
+++ b/test/repositories/in-memory-answer-attachments-repository.ts
@@ -14,6 +14,18 @@ export class InMemoryAnswerAttachmentsRepository
     return answerAttachments
   }
 
+  async createMany(attachments: AnswerAttachment[]) {
+    this.items.push(...attachments)
+  }
+
+  async deleteMany(attachments: AnswerAttachment[]) {
+    const answerAttachments = this.items.filter((item) => {
+      return !attachments.some((attachment) => attachment.equals(item))
+    })
+
+    this.items = answerAttachments
+  }
+
   async deleteManyByAnswerId(answerId: string) {
     const answerAttachments = this.items.filter(
       (item) => item.answerId.toString() !== answerId,


### PR DESCRIPTION
- Add createMany and deleteMany interfaces to answer attachments repository
- Add answer question test to persist attachments when creating a new answer
- Create edit answer test to check new and removed attachments sync when editing an answer
- Update prisma answer attachment mapper with a new toPrismaUpdateMany mapper
- Implement Prisma answer attachments & Prisma answers repository methods
- Update answer question controller with attachments
- Update edit question controller with attachments
- Add makePrismaAnswerAttachment & makePrismaQuestionAttachment factories
- Fix edit answer controller to set an empty array of attachments if not provided by the frontend
- Add tests to edit answer and edit question controllers to check if the attachments are being created and updated correctly
